### PR TITLE
(merge waiting for decision) Only run omega in those gene-sample-impact cases with mutations

### DIFF
--- a/omega/src/estimator/assemble.py
+++ b/omega/src/estimator/assemble.py
@@ -232,4 +232,7 @@ class Assembler:
                     if np.all(l == 0.):
                         logger.warning(f"Lambdas are 0, we are ignoring this case {sample_set}, {impact_set}, {gene_set}.")
                         continue
+                    if np.all(n == 0.):
+                        logger.warning(f"There is no mutation, we are ignoring this case {sample_set}, {impact_set}, {gene_set}.")
+                        continue
                     yield (gene_term, sample_term, impact_term, gene_set, sample_set, impact_set, l, n)


### PR DESCRIPTION
- Skip cases with no mutations
- This makes the run more efficient, but we might also be missing part of the information since there could be genes with no mutations at all in which we would expect to see mutations, pointing to "negative selection"

Decision needed, otherwise we can also add it as an option for the method and the user chooses what to do when running the command.