### PR TITLE
add new fix of global loc mutation redistribution

### DIFF
--- a/omega/main.py
+++ b/omega/main.py
@@ -43,11 +43,12 @@ def omega():
 @click.option('--table-observed-muts', type=click.Path(), help='Path to table of observed mutations file. We recommend: mutability_per_sample_gene_context.tsv')
 @click.option('--mutabilities-table', type=click.Path(), help='Path to mutabilities table file. We recommend: mutations_per_sample_gene_impact_context.count.tsv')
 @click.option('--synonymous-muts-table', type=click.Path(), help='Path to table of observed synonymous mutations per gene file. We recommend: syn_muts_per_gene.tsv')
-@click.option('--mutational-profile', type=click.Path(exists=True), help='Path to table of mutational profile.')
+@click.option('--mutational-profile-file', type=click.Path(exists=True), help='Path to table of mutational profile.')
+@click.option('--mutational-profile-global-file', type=click.Path(), default = None, help='Path to table of mutational profile for the "sample" in which global mutation rates were computed.')
 @click.option('--genome-assembly', type=click.Choice(['hg38', 'hg19', 'mm10']), default = 'hg38', help='Genome assembly')
 @click.option('--single-sample', type=click.STRING, default = None, help='Name of the single sample. It also serves for activating the single sample mode.')
 @click.option('--absent-synonymous', type=click.Choice(['ignore', 'infer_global_custom', 'infer_covariates']), default = 'ignore', help='Omega mode for genes without synonymous mutations.')
-@click.option('--relative-synonymous-muts-file', type=click.Path(), default = None, help='Path to table of synonymous mutations per gene.')
+@click.option('--synonymous-mutrates-file', type=click.Path(), default = None, help='Path to table of synonymous mutation rates per gene.')
 @setup_logging_decorator
 def preprocessing(preprocessing_mode,
                     bed_regions_file, vep_input_generated,
@@ -56,11 +57,12 @@ def preprocessing(preprocessing_mode,
                     depths_file, mutations_file,
                     table_observed_muts, mutabilities_table,
                     synonymous_muts_table,
-                    mutational_profile,
+                    mutational_profile_file,
+                    mutational_profile_global_file,
                     genome_assembly,
                     single_sample,
                     absent_synonymous,
-                    relative_synonymous_muts_file
+                    synonymous_mutrates_file
             ):
     """"Build datasets necessary to run Omega."""
     startup_message(__version__, "Initializing preprocessing...")
@@ -77,11 +79,12 @@ def preprocessing(preprocessing_mode,
     logger.info(f"table_observed_muts: {table_observed_muts}")
     logger.info(f"mutabilities_table: {mutabilities_table}")
     logger.info(f"syn_muts_table: {synonymous_muts_table}")
-    logger.info(f"mutational_profile: {mutational_profile}")
+    logger.info(f"mutational_profile: {mutational_profile_file}")
+    logger.info(f"mutational_profile global: {mutational_profile_global_file}")
     logger.info(f"genome_assembly: {genome_assembly}")
     logger.info(f"single_sample: {single_sample}")
     logger.info(f"absent_synonymous: {absent_synonymous}")
-    logger.info(f"relative_synonymous_muts_file: {relative_synonymous_muts_file}")
+    logger.info(f"relative_synonymous_muts_file: {synonymous_mutrates_file}")
 
     preprocessing_main(preprocessing_mode,
                         bed_regions_file, vep_input_generated,
@@ -90,11 +93,12 @@ def preprocessing(preprocessing_mode,
                         depths_file, mutations_file,
                         table_observed_muts, mutabilities_table,
                         synonymous_muts_table,
-                        mutational_profile,
+                        mutational_profile_file,
+                        mutational_profile_global_file,
                         genome_assembly,
                         single_sample,
                         absent_synonymous,
-                        relative_synonymous_muts_file)
+                        synonymous_mutrates_file)
 
 
 @omega.command(context_settings=dict(help_option_names=['-h', '--help']),

--- a/omega/src/preprocessing/compute_mutabilities.py
+++ b/omega/src/preprocessing/compute_mutabilities.py
@@ -229,6 +229,11 @@ def compute_mutational_profile(annotated_minimal_maf, all_possible_sites_annotat
 
 def compute_expected_synonymous_mutations(all_possible_sites_annotated, depth_dataframe, mut_probability, samples, single_sample = False):
     """
+    Goal:
+        Based on the number of sites, depth, and mutational profile, infer how many synonymous mutation we would expect to see.
+        This comes from absolute vales, such as the depth, but also relative values such as the mutation probablity,
+        however we are not using the absolute value of depth at any time, only as a measure of a position being covered or not.
+
     Required information:
             All possible sites in the panel regions
             Depth per site per sample (only used as a binary dataframe, covered or not covered)
@@ -369,31 +374,50 @@ def compute_mutabilities(alpha_per_sample, mut_probability, samples):
 
 
 def adapt_mutational_profile(mut_profile_file, samples):
-    '''
-    When the user provides a custom mutational profile to be used in the process
-    this function processes it to make sure that:
-    - it has the proper format
-    - if there is any 0 we add the minimum value of the mutational profile as a pseudocount and renormalize
-    '''
+    """
+    Process a custom mutational profile provided by the user to ensure:
+        - Proper format.
+        - Any zeros are replaced with a pseudocount equal to the minimum non-zero value, 
+          followed by renormalization.
+    
+    Args:
+        mut_profile_file (str): Path to the mutational profile file (tab-separated).
+        samples (list): List of sample names to include in the process.
 
-    mut_probability = pd.read_csv(mut_profile_file, sep = "\t", header = 0, index_col = 0)
-    mut_probability.columns = [ x.split(".")[0] for x in mut_probability.columns ]
+    Returns:
+        pd.DataFrame: Processed mutational profile with appropriate pseudocounts and normalization.
+    
+    Note: this function can receive a dataframe containing a column per sample and should be able to handle it
+    """
+    # Load the mutational profile
+    mut_probability = pd.read_csv(mut_profile_file, sep="\t", header=0, index_col=0)
+    mut_probability.columns = [x.split(".")[0] for x in mut_probability.columns]
+
+    # Filter for the specified samples
     mut_probability = mut_probability[samples].copy()
 
-    empty_matrix = pd.DataFrame(index = contexts_formatted)
-    mut_probability = pd.concat( (empty_matrix, mut_probability) , axis = 1)
+    # Create an empty matrix with all contexts, filling missing entries with zeros
+    empty_matrix = pd.DataFrame(index=contexts_formatted)
+    mut_probability = pd.concat((empty_matrix, mut_probability), axis=1)
     mut_probability = mut_probability.fillna(0)
-    
-    # if there is any null value, add a pseudocount
+
+    # If there are zeros, add a pseudocount
     if (mut_probability == 0).any().any():
-        # Add 0.5 to all values
-        logger.info("Adding a pseudocount of {}".format(min(mut_probability)))
-        mut_probability += min(mut_probability)
+        # Add pseudocount: minimum non-zero value
+        min_value = mut_probability[mut_probability > 0].min().min()
+        pseudocount = min_value if min_value > 0 else 1e-6  # Fallback to a small value if necessary
+        logger.info("Adding a pseudocount of {}".format(pseudocount))
+        mut_probability += pseudocount
 
-    mut_probability = mut_probability / mut_probability.sum()
+    # Renormalize each column (sample) independently
+    mut_probability = mut_probability.div(mut_probability.sum(axis=0), axis=1)
 
+    # Add the context mutation name to the index
     mut_probability.index.name = "CONTEXT_MUT"
     return mut_probability.reset_index()
+
+
+
 
 
 def compute_mutabilities_wrapper(all_possible_sites_annotated_file,

--- a/omega/src/preprocessing/compute_mutabilities.py
+++ b/omega/src/preprocessing/compute_mutabilities.py
@@ -260,6 +260,9 @@ def compute_expected_synonymous_mutations(all_possible_sites_annotated, depth_da
         logger.debug(all_possible_sites_per_sample.columns)
         samples_names = [x for x in all_possible_sites_per_sample.columns if x not in ["CHROM", "POS", "REF", "ALT", "GENE", "IMPACT", "CONTEXT_MUT"] ]
         logger.debug(samples_names)
+
+        # this number should be at most, the total number of samples in the group that is being run
+        # whenever you are running a group this should never be 1...
         sites_per_gene_impact_context_sample_wide = all_possible_sites_per_sample.groupby(
                                                                     by = ["GENE", "IMPACT", "CONTEXT_MUT"])[samples_names].sum().sum(axis=1).reset_index()
         sites_per_gene_impact_context_sample_wide.columns = ["GENE", "IMPACT", "CONTEXT_MUT", single_sample]
@@ -317,6 +320,9 @@ def compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, sa
     all_possible_synonymous_sites = all_possible_sites_annotated[all_possible_sites_annotated["IMPACT"] == "synonymous"][["CHROM", "POS", "GENE"]].reset_index(drop = True)
     all_synonymous_sites_depth = all_possible_synonymous_sites.merge(depth_dataframe, on = ["CHROM", "POS"], how = "left")
 
+    # all_synonymous_sites_depth
+    # contains information about: gene, trinucleotide and depth
+
     # wide format
     if single_sample:
         logger.debug("Running in single sample mode.")
@@ -342,6 +348,91 @@ def compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, sa
 
     return depth_per_gene_sample_wide, relative_depth_per_gene_sample_wide
     #return relative_depth_per_gene_sample_wide
+
+
+
+def compute_sample_gene_specific_differences(all_possible_sites_annotated, depth_dataframe,
+                                               mut_probability_total,
+                                               mut_probability,
+                                               samples, single_sample = False):
+    """
+    Required information:
+            All possible sites in the panel regions
+            Depth per site per sample
+            mutational profile
+    Output:
+        mean coverage per gene & sample
+        relative coverage per gene within sample
+    """
+    all_possible_synonymous_sites = all_possible_sites_annotated[all_possible_sites_annotated["IMPACT"] == "synonymous"][["CHROM", "POS", "GENE", "CONTEXT_MUT"]].reset_index(drop = True)
+    
+    # annotate the synonymous sites with depth information
+    all_synonymous_sites_depth = all_possible_synonymous_sites.merge(depth_dataframe, on = ["CHROM", "POS"], how = "left")
+    # contains information about: gene, trinucleotide and depth
+    logger.debug("Depth in synonymous sites of the gene")
+    print(all_synonymous_sites_depth.head())
+    print(all_synonymous_sites_depth.sum())
+
+    # # wide format
+    # if single_sample:
+    #     logger.debug("Running in single sample mode.")
+    #     logger.debug(all_synonymous_sites_depth.columns)
+    #     samples_names = [x for x in all_synonymous_sites_depth.columns if x not in ["CHROM", "POS", "REF", "ALT", "GENE", "IMPACT", "CONTEXT_MUT"] ]
+    #     logger.debug(samples_names)
+    #     depth_per_context_gene_sample_wide = all_synonymous_sites_depth.groupby(
+    #                                                                 by = ["GENE", "CONTEXT_MUT"])[samples_names].sum().sum(axis=1).reset_index()
+    #     depth_per_context_gene_sample_wide.columns = ["GENE", single_sample]
+    
+    samples_names = [x for x in all_synonymous_sites_depth.columns if x not in ["CHROM", "POS", "REF", "ALT", "GENE", "IMPACT", "CONTEXT_MUT"] ]
+    logger.debug(samples_names)
+
+    # group all positions by GENE n CONTEXT_MUT,
+    # we do not expect any differences within trinucleotides of the same gene, except for the depth,
+    # but we are not looking at specific position differences here, but more at the gene level
+    depth_per_context_gene_sample_wide = all_synonymous_sites_depth.groupby(
+                                                                by = ["GENE", "CONTEXT_MUT"])[samples].sum().reset_index()
+    depth_per_context_gene_sample_wide[samples] = depth_per_context_gene_sample_wide[samples].fillna(0).astype(float)
+    
+    print(depth_per_context_gene_sample_wide.head())
+
+    mut_probability_ind = mut_probability.set_index("CONTEXT_MUT")
+    mut_probability_total_ind = mut_probability_total.set_index("CONTEXT_MUT")
+    # normalize sample specific mutational profile compared to the all_samples one
+    mut_probability_norm = (mut_probability_ind / mut_probability_total_ind).reset_index()
+    # print(mut_probability_norm)
+
+    # merge the depth per context gene with the correction of the mutation probability
+    probability_depth_per_context_gene_sample_wide = depth_per_context_gene_sample_wide.merge(mut_probability_norm,
+                                                                                  on = 'CONTEXT_MUT',
+                                                                                  suffixes = [".sites", ".probability_correction"],
+                                                                                  )
+    print(probability_depth_per_context_gene_sample_wide.head())
+
+    # apply the correction of difference in mutational profile
+    corrected_depth_per_context_gene_sample_wide = probability_depth_per_context_gene_sample_wide[["GENE", "CONTEXT_MUT"]].copy()
+    for sample in samples:
+        corrected_depth_per_context_gene_sample_wide[sample] = probability_depth_per_context_gene_sample_wide[f"{sample}.sites"] * probability_depth_per_context_gene_sample_wide[f"{sample}.probability_correction"]
+
+    # add up all the corrections to gene level depth
+    context_corrected_depth_per_gene_sample_wide = corrected_depth_per_context_gene_sample_wide.groupby(
+                                                                    by = ["GENE"])[samples].sum()
+
+    # print(context_corrected_depth_per_gene_sample_wide)
+    # then we should multiply this by the gene mutation rate per bp
+    
+    # gene_mutrate_per_bp_allsamples
+    # should be a GENE indexed pandas.Series that contains what it's name suggests
+
+    # result = context_corrected_depth_per_gene_sample_wide * gene_mutrate_per_bp_allsamples
+    # result # is potentially already a candidate number of synonymous mutations per gene in the sample
+
+    # result2 = num_synonymous * ( result /result.sum() )
+
+
+    return context_corrected_depth_per_gene_sample_wide
+    #return relative_depth_per_gene_sample_wide
+
+
 
 
 def compute_mutabilities(alpha_per_sample, mut_probability, samples):
@@ -433,7 +524,8 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
                                     mut_profile = None,
                                     single_sample = None,
                                     absent_synonymous = 'ignore',
-                                    relative_synonymous_muts_file = None
+                                    relative_synonymous_muts_file = None,
+                                    gene_mutation_rates_file = 'mutation_rates_per_gene.tsv'
                                     ):
     """
     Wrapper for all the steps required to compute the mutabilities per sample, gene and context
@@ -469,6 +561,10 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
         logger.debug("Mutations subsetted")
 
     depth_dataframe = depth_dataframe[["CHROM", "POS"] + samples].copy()
+    print(depth_dataframe.head())
+    depth_dataframe_small = depth_dataframe[["CHROM", "POS"] + samples].copy()
+    depth_dataframe_small[samples] = depth_dataframe_small[samples]/3
+    print(depth_dataframe_small.head())
     logger.debug("Depths subsetted")
 
 
@@ -504,6 +600,11 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
     # Compute mutational profile from the input data
     if mut_profile:
         mut_probability = adapt_mutational_profile(mut_profile, samples)
+        mut_profile2 = pd.read_table("P19_0033_BTR_01.all.profile.tsv")
+        print(mut_profile2.columns)
+        mut_probability2 = adapt_mutational_profile("P19_0033_BTR_01.all.profile.tsv", ["P19_0033_BTR_01"])
+        print(mut_probability2.columns)
+        mut_probability2.columns = ['CONTEXT_MUT', 'all_samples']
         logger.info("Mutational profile loaded")
 
     else:
@@ -516,7 +617,6 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
 
 
     # until here looks good to me
-    # only a minimal change required to ensure that the mutational_profile can also be provided for multiple samples at once
 
     # Compute expected synonymous mutations
     expected_syn_per_gene_per_sample = compute_expected_synonymous_mutations(all_possible_sites_annotated,
@@ -524,6 +624,41 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
                                                                                 mut_probability,
                                                                                 samples)
     logger.debug("Expected synonymous computed")
+
+
+    gene_mutation_rates = pd.read_table(gene_mutation_rates_file)
+    gene_mutation_rates = gene_mutation_rates.set_index('GENE')
+    gene_mutation_rates = gene_mutation_rates / 1e6
+
+    sample_specific_biases = compute_sample_gene_specific_differences(all_possible_sites_annotated,
+                                             depth_dataframe_small,
+                                             mut_probability,
+                                             mut_probability2,
+                                             samples)
+    print(sample_specific_biases)
+    print(gene_mutation_rates)
+
+    mutation_numbers = sample_specific_biases.merge(gene_mutation_rates, on = 'GENE').fillna(0)
+    print(mutation_numbers)
+
+    mutation_numbers = mutation_numbers.iloc[:,0] * mutation_numbers.iloc[:,1]
+    print("computed synonymous mutation numbers")
+    print(mutation_numbers)
+
+
+    print(obs_muts_per_gene_impact_context_sample_wide[
+                                                            obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
+                                                        ].reset_index(drop = True)[samples].sum()
+    )
+
+
+    print(obs_muts_per_gene_impact_context_sample_wide[
+                                                            obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
+                                                        ].reset_index(drop = True).groupby(by = 'GENE')[samples].sum()
+    )
+
+    exit(1)
+
 
 
     if absent_synonymous == 'infer_global_custom':
@@ -535,7 +670,12 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
         relative_syn_muts_per_gene_allsamples = relative_syn_muts_per_gene_allsamples / relative_syn_muts_per_gene_allsamples.sum()
 
         # Add adjustment based on relative average depth per gene
-        abs_depth_per_gene, relative_depth_per_gene = compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples)
+        abs_depth_per_gene, relative_depth_per_gene = compute_sample_gene_specific_differences(all_possible_sites_annotated,
+                                                                                                 depth_dataframe_small,
+                                                                                                 mut_probability,
+                                                                                                 mut_probability,
+                                                                                                 samples)
+        # abs_depth_per_gene, relative_depth_per_gene = compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples)
         # relative_depth_per_gene = compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples)
 
 

--- a/omega/src/preprocessing/compute_mutabilities.py
+++ b/omega/src/preprocessing/compute_mutabilities.py
@@ -307,50 +307,6 @@ def compute_expected_synonymous_mutations(all_possible_sites_annotated, depth_da
     
     return expected_syn_per_gene_per_sample
 
-
-def compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples, single_sample = False):
-    """
-    Required information:
-            All possible sites in the panel regions
-            Depth per site per sample
-    Output:
-        mean coverage per gene & sample
-        relative coverage per gene within sample
-    """
-    all_possible_synonymous_sites = all_possible_sites_annotated[all_possible_sites_annotated["IMPACT"] == "synonymous"][["CHROM", "POS", "GENE"]].reset_index(drop = True)
-    all_synonymous_sites_depth = all_possible_synonymous_sites.merge(depth_dataframe, on = ["CHROM", "POS"], how = "left")
-
-    # all_synonymous_sites_depth
-    # contains information about: gene, trinucleotide and depth
-
-    # wide format
-    if single_sample:
-        logger.debug("Running in single sample mode.")
-        logger.debug(all_synonymous_sites_depth.columns)
-        samples_names = [x for x in all_synonymous_sites_depth.columns if x not in ["CHROM", "POS", "REF", "ALT", "GENE", "IMPACT", "CONTEXT_MUT"] ]
-        logger.debug(samples_names)
-        depth_per_gene_sample_wide = all_synonymous_sites_depth.groupby(
-                                                                    by = ["GENE"])[samples_names].sum().sum(axis=1).reset_index()
-        depth_per_gene_sample_wide.columns = ["GENE", single_sample]
-
-    else:
-        depth_per_gene_sample_wide = all_synonymous_sites_depth.groupby(
-                                                                    by = ["GENE"])[samples].sum().reset_index()
-
-    depth_per_gene_sample_wide[samples] = depth_per_gene_sample_wide[samples].fillna(0).astype(float)
-
-    depth_per_gene_sample_wide = depth_per_gene_sample_wide.set_index("GENE")
-
-    # Then, we would only need to correct for the differences in coverage between the genes within a sample.
-    # We could do this by computing the average depth per gene and then center the vector to 1. 
-    # RDgenes specific for each sample.
-    relative_depth_per_gene_sample_wide = depth_per_gene_sample_wide[samples] / depth_per_gene_sample_wide[samples].mean()
-
-    return depth_per_gene_sample_wide, relative_depth_per_gene_sample_wide
-    #return relative_depth_per_gene_sample_wide
-
-
-
 def compute_sample_gene_specific_differences(all_possible_sites_annotated, depth_dataframe,
                                                mut_probability_total,
                                                mut_probability,
@@ -444,7 +400,6 @@ def compute_sample_gene_specific_differences(all_possible_sites_annotated, depth
 
 
     return context_corrected_depth_per_gene_sample_wide
-    #return relative_depth_per_gene_sample_wide
 
 
 
@@ -690,12 +645,6 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
 
 
         print(obs_muts_per_gene_impact_context_sample_wide[
-                                                            obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
-                                                            ].reset_index(drop = True)[samples].sum()
-        )
-
-
-        print(obs_muts_per_gene_impact_context_sample_wide[
                                                                 obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
                                                             ].reset_index(drop = True).groupby(by = 'GENE')[samples].sum()
         )
@@ -801,22 +750,22 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
 
 
 
-if __name__ == '__main__':
+# if __name__ == '__main__':
 
-    ## Input
-    depth_dataframe_file = "/workspace/datasets/prominent/data/kidney/depth/2023-06-30.kidney_panel.chr.633.tsv.gz"
-    mutations_file = "/workspace/datasets/prominent/data/kidney/mutations/2023-06-30.kidney.633.maf.annot.tsv.gz"
-    all_possible_sites_annotated_file = "./test/preprocessing/KidneyPanel.sites.bed_panel.annotation_summary.tsv"
+#     ## Input
+#     depth_dataframe_file = "/workspace/datasets/prominent/data/kidney/depth/2023-06-30.kidney_panel.chr.633.tsv.gz"
+#     mutations_file = "/workspace/datasets/prominent/data/kidney/mutations/2023-06-30.kidney.633.maf.annot.tsv.gz"
+#     all_possible_sites_annotated_file = "./test/preprocessing/KidneyPanel.sites.bed_panel.annotation_summary.tsv"
 
-    ## Output
-    table_muts_x_sample_gene_impact_context = "./test/preprocessing/mutations_per_sample_gene_impact_context.count.tsv"
-    mutabilities_table = "./test/preprocessing/mutability_per_sample_gene_context.tsv"
+#     ## Output
+#     table_muts_x_sample_gene_impact_context = "./test/preprocessing/mutations_per_sample_gene_impact_context.count.tsv"
+#     mutabilities_table = "./test/preprocessing/mutability_per_sample_gene_context.tsv"
 
-    compute_mutabilities_wrapper(all_possible_sites_annotated_file,
-                                    depth_dataframe_file,
-                                    mutations_file, 
-                                    table_muts_x_sample_gene_impact_context,
-                                    mutabilities_table
-                                    )
+#     compute_mutabilities_wrapper(all_possible_sites_annotated_file,
+#                                     depth_dataframe_file,
+#                                     mutations_file, 
+#                                     table_muts_x_sample_gene_impact_context,
+#                                     mutabilities_table
+#                                     )
 
 

--- a/omega/src/preprocessing/compute_mutabilities.py
+++ b/omega/src/preprocessing/compute_mutabilities.py
@@ -368,10 +368,12 @@ def compute_sample_gene_specific_differences(all_possible_sites_annotated, depth
     
     # annotate the synonymous sites with depth information
     all_synonymous_sites_depth = all_possible_synonymous_sites.merge(depth_dataframe, on = ["CHROM", "POS"], how = "left")
-    # contains information about: gene, trinucleotide and depth
-    logger.debug("Depth in synonymous sites of the gene")
-    print(all_synonymous_sites_depth.head())
-    print(all_synonymous_sites_depth.sum())
+    # contains information about: gene, chromosome, positions, trinucleotide and depth
+    # logger.debug("Depth in synonymous sites of the gene")
+    # print(all_synonymous_sites_depth.head())
+    # print(all_synonymous_sites_depth.sum())
+
+
 
     # # wide format
     # if single_sample:
@@ -397,8 +399,20 @@ def compute_sample_gene_specific_differences(all_possible_sites_annotated, depth
 
     mut_probability_ind = mut_probability.set_index("CONTEXT_MUT")
     mut_probability_total_ind = mut_probability_total.set_index("CONTEXT_MUT")
+
+    print(mut_probability_ind.sum())
+    print(mut_probability_total_ind.sum())
+
+    # TODO
+    # revise if this division makes sense or we would need to center the resulting vector or something
+
     # normalize sample specific mutational profile compared to the all_samples one
     mut_probability_norm = (mut_probability_ind / mut_probability_total_ind).reset_index()
+    # mut_probability_norm = ( mut_probability_total_ind / mut_probability_ind).reset_index()
+    # print(mut_probability_total_ind / mut_probability_ind)
+    # print((mut_probability_total_ind / mut_probability_ind).sum())
+    # print(mut_probability_ind / mut_probability_total_ind)
+    # print((mut_probability_ind / mut_probability_total_ind).sum())
     # print(mut_probability_norm)
 
     # merge the depth per context gene with the correction of the mutation probability
@@ -468,7 +482,7 @@ def compute_mutabilities(alpha_per_sample, mut_probability, samples):
 
 
 
-def adapt_mutational_profile(mut_profile_file, samples):
+def adapt_mutational_profile(mut_profile_file, samples = None):
     """
     Process a custom mutational profile provided by the user to ensure:
         - Proper format.
@@ -488,14 +502,17 @@ def adapt_mutational_profile(mut_profile_file, samples):
     mut_probability = pd.read_csv(mut_profile_file, sep="\t", header=0, index_col=0)
     mut_probability.columns = [x.split(".")[0] for x in mut_probability.columns]
 
-    # Filter for the specified samples
-    mut_probability = mut_probability[samples].copy()
+    if samples is not None:
+        # Filter for the specified samples
+        mut_probability = mut_probability[samples].copy()
 
     # Create an empty matrix with all contexts, filling missing entries with zeros
     empty_matrix = pd.DataFrame(index=contexts_formatted)
     mut_probability = pd.concat((empty_matrix, mut_probability), axis=1)
     mut_probability = mut_probability.fillna(0)
 
+    # TODO
+    # revise that this way of adding a pseudocount makes sense
     # If there are zeros, add a pseudocount
     if (mut_probability == 0).any().any():
         # Add pseudocount: minimum non-zero value
@@ -522,10 +539,10 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
                                     mutability_table,
                                     syn_muts_table,
                                     mut_profile = None,
+                                    mut_profile_global = None,
                                     single_sample = None,
                                     absent_synonymous = 'ignore',
-                                    relative_synonymous_muts_file = None,
-                                    gene_mutation_rates_file = 'mutation_rates_per_gene.tsv'
+                                    gene_mutation_rates_file = None
                                     ):
     """
     Wrapper for all the steps required to compute the mutabilities per sample, gene and context
@@ -538,8 +555,11 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
 
     if absent_synonymous == 'infer_global_custom':
         # check if exists
-        if not os.path.isfile(relative_synonymous_muts_file):
-            logger.debug(f"Relative synonymous mutations file : {relative_synonymous_muts_file} does not exist")
+        if not os.path.isfile(gene_mutation_rates_file):
+            logger.debug(f"Gene synonymous mutations file : {gene_mutation_rates_file} does not exist")
+        if not os.path.isfile(mut_profile_global):
+            logger.debug(f"Global mutational profile file : {mut_profile_global} does not exist")
+            
 
     logger.debug("Inputs loaded")
     # Annotate mutations
@@ -561,10 +581,8 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
         logger.debug("Mutations subsetted")
 
     depth_dataframe = depth_dataframe[["CHROM", "POS"] + samples].copy()
-    print(depth_dataframe.head())
     depth_dataframe_small = depth_dataframe[["CHROM", "POS"] + samples].copy()
     depth_dataframe_small[samples] = depth_dataframe_small[samples]/3
-    print(depth_dataframe_small.head())
     logger.debug("Depths subsetted")
 
 
@@ -600,98 +618,96 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
     # Compute mutational profile from the input data
     if mut_profile:
         mut_probability = adapt_mutational_profile(mut_profile, samples)
-        mut_profile2 = pd.read_table("P19_0033_BTR_01.all.profile.tsv")
-        print(mut_profile2.columns)
-        mut_probability2 = adapt_mutational_profile("P19_0033_BTR_01.all.profile.tsv", ["P19_0033_BTR_01"])
-        print(mut_probability2.columns)
-        mut_probability2.columns = ['CONTEXT_MUT', 'all_samples']
-        logger.info("Mutational profile loaded")
+        logger.info("Mutational profile loaded")       
 
     else:
         mut_probability = compute_mutational_profile(annotated_minimal_maf,
                                                         all_possible_sites_annotated,
                                                         depth_dataframe,
                                                         samples,
-                                                        pseudocount = 0.5)
+                                                        pseudocount = 0.5 # FIXME revise if this value makes sense
+                                                        )
         logger.info("Mutational profile computed")
-
 
     # until here looks good to me
 
+
+    # I want to revise this one in more detail.
     # Compute expected synonymous mutations
     expected_syn_per_gene_per_sample = compute_expected_synonymous_mutations(all_possible_sites_annotated,
                                                                                 depth_dataframe,
                                                                                 mut_probability,
                                                                                 samples)
-    logger.debug("Expected synonymous computed")
-
-
-    gene_mutation_rates = pd.read_table(gene_mutation_rates_file)
-    gene_mutation_rates = gene_mutation_rates.set_index('GENE')
-    gene_mutation_rates = gene_mutation_rates / 1e6
-
-    sample_specific_biases = compute_sample_gene_specific_differences(all_possible_sites_annotated,
-                                             depth_dataframe_small,
-                                             mut_probability,
-                                             mut_probability2,
-                                             samples)
-    print(sample_specific_biases)
-    print(gene_mutation_rates)
-
-    mutation_numbers = sample_specific_biases.merge(gene_mutation_rates, on = 'GENE').fillna(0)
-    print(mutation_numbers)
-
-    mutation_numbers = mutation_numbers.iloc[:,0] * mutation_numbers.iloc[:,1]
-    print("computed synonymous mutation numbers")
-    print(mutation_numbers)
-
-
-    print(obs_muts_per_gene_impact_context_sample_wide[
-                                                            obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
-                                                        ].reset_index(drop = True)[samples].sum()
-    )
-
-
-    print(obs_muts_per_gene_impact_context_sample_wide[
-                                                            obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
-                                                        ].reset_index(drop = True).groupby(by = 'GENE')[samples].sum()
-    )
-
-    exit(1)
+    logger.debug("Theoretical expected synonymous computed")
 
 
 
     if absent_synonymous == 'infer_global_custom':
-        relative_syn_muts_per_gene_allsamples = pd.read_csv(relative_synonymous_muts_file,
-                                                        sep = "\t", header = 0,
-                                                        dtype = {"GENE" : str, "SYNONYMOUS_MUTS": float}).set_index("GENE")
+        ## FIXME
+        # this will keep the original samples' name, even multiple columns if single sample is not activated
+        mut_probability_global = adapt_mutational_profile(mut_profile_global)
 
-        # Normalize the counts of mutations per gene to ensure that the values are relative and sum to 1
-        relative_syn_muts_per_gene_allsamples = relative_syn_muts_per_gene_allsamples / relative_syn_muts_per_gene_allsamples.sum()
+        # this might not work if there are more than one column            
+        mut_probability_global.columns = ['CONTEXT_MUT'] + samples
+        logger.info("Global mutational profile loaded")
 
-        # Add adjustment based on relative average depth per gene
-        abs_depth_per_gene, relative_depth_per_gene = compute_sample_gene_specific_differences(all_possible_sites_annotated,
-                                                                                                 depth_dataframe_small,
-                                                                                                 mut_probability,
-                                                                                                 mut_probability,
-                                                                                                 samples)
-        # abs_depth_per_gene, relative_depth_per_gene = compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples)
-        # relative_depth_per_gene = compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples)
-
-
+        #######
+        ## the following lines follow this correction strategy
+        #######
         # syn_mutrate * (depth * (sample_mut_profile/all_samples_mut_profile) )
+        #######
+
+        # this term is loaded from the cohort information:
+        # syn_mutrate
+
+        # Read mutation rates per MB
+        gene_mutation_rates = pd.read_table(gene_mutation_rates_file)
+        gene_mutation_rates = gene_mutation_rates.set_index('GENE')
+        logger.info("Gene mutation rates loaded")
+        
+        ## FIXME
+        # revise if this should be changed and mutrates should be provided without normalization
+
+        # remove the per MB correction
+        gene_mutation_rates = gene_mutation_rates / 1e6
+
+        # this term is computed here
+        # (depth * (sample_mut_profile/all_samples_mut_profile) )
+        # we get a value per gene
+        sample_specific_biases = compute_sample_gene_specific_differences(all_possible_sites_annotated,
+                                                depth_dataframe_small,
+                                                mut_probability_global,
+                                                mut_probability,                                                
+                                                samples)
+        logger.info("Sample specific biases computed based on mutational profile and sequencing depth")
+
+        weighted_depth_n_mutrate = sample_specific_biases.merge(gene_mutation_rates, on = 'GENE').fillna(0)
+        print(weighted_depth_n_mutrate)
+
+        mutation_numbers = weighted_depth_n_mutrate.iloc[:,0] * weighted_depth_n_mutrate.iloc[:,1]
+        print("computed synonymous mutation numbers from global mutrate")
+        print(mutation_numbers)
 
 
+        print(obs_muts_per_gene_impact_context_sample_wide[
+                                                            obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
+                                                            ].reset_index(drop = True)[samples].sum()
+        )
 
-        # multiply the vector correcting for the general distribution of mutations
-        # and the relative depth per gene per sample
-        correction_per_gene_sample = relative_depth_per_gene.merge(relative_syn_muts_per_gene_allsamples, on = "GENE", how = 'outer')
 
-        for sampleee in samples:
-            correction_per_gene_sample[sampleee] = correction_per_gene_sample[sampleee] * correction_per_gene_sample["SYNONYMOUS_MUTS"]
+        print(obs_muts_per_gene_impact_context_sample_wide[
+                                                                obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
+                                                            ].reset_index(drop = True).groupby(by = 'GENE')[samples].sum()
+        )
 
-        correction_per_gene_sample = (correction_per_gene_sample[samples] / correction_per_gene_sample[samples].sum()).fillna(0)
 
+        # mutation_numbers 
+        # is a potential output number of mutations per gene per sample
+        # using the global synonymous mutation rates
+
+        # the alternative option is to use the counts from mutation_numbers
+        # to redistribute the observed number of synonymous mutations observed in that sample
+        relative_syn_muts_per_gene_allsamples = mutation_numbers / mutation_numbers.sum()
 
 
         # Count how many synonymous mutations are there in each sample irrespective of the gene
@@ -701,28 +717,19 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
         syn_muts_per_sample_df = pd.DataFrame(syn_muts_per_sample).T
 
 
-
         # Multiply the two "vectors" to get a value of synonymous mutations per sample per gene
         result_array = relative_syn_muts_per_gene_allsamples.values * syn_muts_per_sample_df.values
 
         # put the right names to the rows and columns
-        obs_syn_muts_per_gene_sample = pd.DataFrame(result_array,
+        obs_syn_muts_per_gene_sample = pd.DataFrame(result_array.T,
                                                             columns= syn_muts_per_sample_df.columns,
                                                             index=relative_syn_muts_per_gene_allsamples.index)
         obs_syn_muts_per_gene_sample = obs_syn_muts_per_gene_sample.reset_index()
-        old_obs_syn_muts_per_gene_sample = obs_syn_muts_per_gene_sample.copy()
+        print("computed synonymous mutation numbers after normalizing")
+        print(obs_syn_muts_per_gene_sample)
 
         logger.debug("Synonynmous computed from the total number of observed synonymous and distributed according to the relative counts in the custom file provided.")
         # print('CV', obs_syn_muts_per_gene_sample)
-       
-
-        # Multiply correction_per_gene_sample by syn_muts_per_sample_df to adjust for the number of mutations
-        # We need to make sure that each sample column in correction_per_gene_sample is scaled
-        # by the corresponding value in syn_muts_per_sample_df
-        corrected_mutations_per_gene_sample = correction_per_gene_sample[samples].multiply(syn_muts_per_sample_df[samples].values, axis=1).reset_index()
-
-        obs_syn_muts_per_gene_sample = corrected_mutations_per_gene_sample.copy()
-
 
     elif absent_synonymous == 'infer_covariates':
         pass

--- a/omega/src/preprocessing/compute_mutabilities.py
+++ b/omega/src/preprocessing/compute_mutabilities.py
@@ -95,7 +95,8 @@ def annotate_mutations_using_vep(maf, all_possible_sites_annotated):
 
 
 def compute_mutations_per_sample_gene_impact_context_table(annotated_minimal_maf,
-                                                            impacts_to_exclude = ["non_genic_variant", "intron_variant"]):
+                                                            impacts_to_exclude = ["non_genic_variant", "intron_variant"]
+                                                            ):
     # TODO
     # revise the default list of excluded impacts
     """
@@ -103,6 +104,9 @@ def compute_mutations_per_sample_gene_impact_context_table(annotated_minimal_maf
         - The observed mutations annotated
     and returns:
         - a table with the number of mutations per sample, gene, impact and context
+    
+    here the total number of mutations per sample, gene, impact and context can be higher than the number of sites when counting them 1x
+    if the effective_muts are being computed with the ALT_DEPTH
     """
     # TODO
     # revise whether we are interested in doing it this way or not
@@ -510,6 +514,10 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
                                                         pseudocount = 0.5)
         logger.info("Mutational profile computed")
 
+
+    # until here looks good to me
+    # only a minimal change required to ensure that the mutational_profile can also be provided for multiple samples at once
+
     # Compute expected synonymous mutations
     expected_syn_per_gene_per_sample = compute_expected_synonymous_mutations(all_possible_sites_annotated,
                                                                                 depth_dataframe,
@@ -529,6 +537,9 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
         # Add adjustment based on relative average depth per gene
         abs_depth_per_gene, relative_depth_per_gene = compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples)
         # relative_depth_per_gene = compute_rel_depth_per_gene(all_possible_sites_annotated, depth_dataframe, samples)
+
+
+        # syn_mutrate * (depth * (sample_mut_profile/all_samples_mut_profile) )
 
 
 

--- a/omega/src/preprocessing/compute_mutabilities.py
+++ b/omega/src/preprocessing/compute_mutabilities.py
@@ -362,6 +362,8 @@ def compute_sample_gene_specific_differences(all_possible_sites_annotated, depth
     # TODO
     # revise if this division makes sense or we would need to center the resulting vector or something
 
+    ## URGENT
+
     # normalize sample specific mutational profile compared to the all_samples one
     mut_probability_norm = (mut_probability_ind / mut_probability_total_ind).reset_index()
     # mut_probability_norm = ( mut_probability_total_ind / mut_probability_ind).reset_index()

--- a/omega/src/preprocessing/main.py
+++ b/omega/src/preprocessing/main.py
@@ -18,10 +18,11 @@ def main(preprocessing_mode,
             table_observed_muts, mutabilities_table,
             syn_muts_table,
             mutational_profile,
+            mutational_profile_global,
             genome_assembly,
             single_sample,
             absent_synonymous,
-            relative_synonymous_muts_file
+            synonymous_mut_rates_file
             ):
     
     run_vep = False
@@ -63,8 +64,10 @@ def main(preprocessing_mode,
         compute_mutabilities_wrapper(input_vep_postprocessed_file, depths_file,
                                         mutations_file, table_observed_muts, mutabilities_table,
                                         syn_muts_table,
-                                        mutational_profile, single_sample,
-                                        absent_synonymous, relative_synonymous_muts_file
+                                        mutational_profile, 
+                                        mutational_profile_global,
+                                        single_sample,
+                                        absent_synonymous, synonymous_mut_rates_file
                                     )
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request includes several updates to the `omega/main.py` and `omega/src/preprocessing/compute_mutabilities.py` files to improve functionality and refactor existing code. The most important changes include renaming and adding new command-line options, refactoring functions for better clarity and functionality, and adding detailed comments to explain the code.

## Main changes
* Update redistribution of synonymous mutations between genes of a sample. Following this strategy:
`syn_mutrate_per_gene_in_cohort * (sample_depth_per_trinucleotidechange_per_gene * (sample_mut_profile / in_cohort_mut_profile) )`
after this we take the values obtained and we normalize them to sum up to 1 and multiply by the total number of synonymous mutations observed in the sample, to make sure we are redistributing exactly the same number of mutations only in different proportions.

### Implementation 
When using the synonymous mutation rate of each gene in the all samples cohort, this value is corrected by the sequencing depth per gene since it is a mutation rate, but has been computed with mutations that occurred following a specific mutational profile (aka trinucleotide probability). All this from the full cohort.


When willing to apply these values to a new sample, two main things differ:
* Sequencing depth of each gene/position within the gene.
   To correct for this, what we do is compute the depth of each trinucleotide in a site with a synonymous consequence and add up the depth of all the trinucleotide of that same type for the given gene. So we end up with a vector of at most 96 channels per each gene. Since a single position might have more than one type of site depending on the change, we are not adding up the depth per position but this value divided by 3 in such a way that the contribution of each site is weighted.

* Mutational profile of the mutations occurring in the sample.
  To correct for this we can compare it to the mutational profile of the all_samples cohort where the mutation rates were computed. If the site ACA>T has a higher mutation probability in the specific sample compared to the full cohort, we would expect to see more mutations in the sites that are like this. A way to correct for this is to first compute the differences between the two profiles, which can be done as a ratio between the two (sample / cohort) and then take this vector to update the vector of depths. If a given site is twice more likely to be mutated because the frequency of mutations in that type of trinucleotide change is the double of the same value in the full cohort, when starting from the mutation rate, we can either update the mutation rate of that site by multiplying it by two, or we can multiply by two the depth of the site, the result should be the same.
  The solution we are currently using is the former which means multiplying the vector of depths of the synonymous sites by the vector that contains the ratio between the mutational profile of the sample and the mutational profile of the cohort.

Here the implementation of the function to compute the correction:
https://github.com/bbglab/omega/blob/6d6426475f788ea5abf594d8f173f4bafe7d3012/omega/src/preprocessing/compute_mutabilities.py#L310-L404

here the implementation where I call the function and do the downstream steps:
https://github.com/bbglab/omega/blob/6d6426475f788ea5abf594d8f173f4bafe7d3012/omega/src/preprocessing/compute_mutabilities.py#L602-L682






### Command-line options updates:
* Renamed `--mutational-profile` to `--mutational-profile-file` and added a new option `--mutational-profile-global-file` for global mutation rates. (`omega/main.py`, [omega/main.pyL46-R51](diffhunk://#diff-ec2d60bc16ce718a0568d938c74902911ee0c4d8a0d741bef286ebd7f0515edcL46-R51))
* Renamed `--relative-synonymous-muts-file` to `--synonymous-mutates-file`. (`omega/main.py`, [omega/main.pyL46-R51](diffhunk://#diff-ec2d60bc16ce718a0568d938c74902911ee0c4d8a0d741bef286ebd7f0515edcL46-R51))

### Function refactoring and enhancements:
* Refactored `compute_sample_gene_specific_differences` to include detailed comments and additional steps for processing mutational profiles and depth information. (`omega/src/preprocessing/compute_mutabilities.py`, [omega/src/preprocessing/compute_mutabilities.pyL298-L335](diffhunk://#diff-91421baf34c05f1158ebca30df25b3afb2d3776a2f43788677dc1d5dd4caf968L298-L335))
* Updated `compute_mutabilities_wrapper` to handle new input parameters and added checks for file existence. (`omega/src/preprocessing/compute_mutabilities.py`, [omega/src/preprocessing/compute_mutabilities.pyL421-R519](diffhunk://#diff-91421baf34c05f1158ebca30df25b3afb2d3776a2f43788677dc1d5dd4caf968L421-R519))

### Code comments and documentation:
* Added detailed comments to `compute_expected_synonymous_mutations` to explain the goal and required information for the function. (`omega/src/preprocessing/compute_mutabilities.py`, [omega/src/preprocessing/compute_mutabilities.pyR236-R240](diffhunk://#diff-91421baf34c05f1158ebca30df25b3afb2d3776a2f43788677dc1d5dd4caf968R236-R240))
* Enhanced the `adapt_mutational_profile` function with comments explaining the process of handling custom mutational profiles. (`omega/src/preprocessing/compute_mutabilities.py`, [omega/src/preprocessing/compute_mutabilities.pyL371-R502](diffhunk://#diff-91421baf34c05f1158ebca30df25b3afb2d3776a2f43788677dc1d5dd4caf968L371-R502))

These changes improve the clarity and functionality of the code, making it easier to understand and maintain.