### PR TITLE
Add mutability per site computation

### DIFF
--- a/omega/main.py
+++ b/omega/main.py
@@ -15,11 +15,11 @@ import daiquiri
 
 from omega import __logger_name__, __version__
 
-from omega.src.preprocessing.main import main as preprocessing_main
-from omega.src.estimator.main import run_click as estimator_main
-from omega.src.mutabilities.main import run_click as mutabilities_main
+from omega.src.preprocessing.main   import main as preprocessing_main
+from omega.src.estimator.main       import main as estimator_main
+from omega.src.mutabilities.main    import main as mutabilities_main
 
-from omega.src.globals import DATE, setup_logging_decorator, startup_message
+from omega.src.globals              import DATE, setup_logging_decorator, startup_message
 
 logger = daiquiri.getLogger(__logger_name__)
 

--- a/omega/main.py
+++ b/omega/main.py
@@ -17,6 +17,7 @@ from omega import __logger_name__, __version__
 
 from omega.src.preprocessing.main import main as preprocessing_main
 from omega.src.estimator.main import run_click as estimator_main
+from omega.src.mutabilities.main import run_click as mutabilities_main
 
 from omega.src.globals import DATE, setup_logging_decorator, startup_message
 
@@ -31,7 +32,7 @@ def omega():
 
 
 @omega.command(context_settings=dict(help_option_names=['-h', '--help']),
-                help="Build datasets - Required once after installation.") 
+                help="Build input tables - Required once per cohort.")
 @click.option('--preprocessing-mode', type=click.Choice(['run_vep', 'postprocess_vep', 'compute_mutabilities']), help='Preprocessing mode')
 @click.option('--depths-file', type=click.Path(exists=True), help='Path to depths file')
 @click.option('--mutations-file', type=click.Path(exists=True), help='Path to mutations file')
@@ -64,7 +65,7 @@ def preprocessing(preprocessing_mode,
                     absent_synonymous,
                     synonymous_mutrates_file
             ):
-    """"Build datasets necessary to run Omega."""
+    """"Build tables necessary to run Omega."""
     startup_message(__version__, "Initializing preprocessing...")
 
     logger.info("Received arguments:")
@@ -127,6 +128,28 @@ def estimator(observed_mutations_file, mutability_file, depths_file, vep_annotat
     logger.info(f"option: {option}")
     logger.info(f"cores: {cores}")
     estimator_main(observed_mutations_file, mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, dispersion, option, cores)
+
+
+@omega.command(context_settings=dict(help_option_names=['-h', '--help']),
+                        help="Run dNdS analysis.")
+@click.option('--mutability-file', type=click.Path(exists=True), help='Path to mutability file')
+@click.option('--depths-file', type=click.Path(exists=True), help='Path to depths file')
+@click.option('--vep-annotation-file', type=click.Path(exists=True), help='Path to VEP annotation file')
+@click.option('--grouping-folder', type=click.Path(exists=True), help='Path to grouping folder')
+@click.option('--output-fn', type=str, help='Output filename')
+@click.option('--cores', type=int, default=4, help='Number of cores (default: 4)')
+@setup_logging_decorator
+def mutabilities( mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, cores):
+    startup_message(__version__, "Running estimator...")
+
+    logger.info("Received arguments:")
+    logger.info(f"mutability_file: {mutability_file}")
+    logger.info(f"depths_file: {depths_file}")
+    logger.info(f"vep_annotation_file: {vep_annotation_file}")
+    logger.info(f"grouping_folder: {grouping_folder}")
+    logger.info(f"output_fn: {output_fn}")
+    logger.info(f"cores: {cores}")
+    mutabilities_main(mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, cores)
 
 
 if __name__ == "__main__":

--- a/omega/src/estimator/main.py
+++ b/omega/src/estimator/main.py
@@ -5,7 +5,6 @@ import warnings
 
 import pandas as pd
 
-# from enum import Enum
 from multiprocessing import Pool
 
 
@@ -72,22 +71,7 @@ def mle(input_json: str, output_fn: str, dispersion : float, cores=4):
 
 
 
-# class ModelType(str, Enum):
-#     bayes = "bayes"
-#     mle = "mle"
-
-
-# def run(input_json: str, output_fn: str, option: ModelType=ModelType.bayes, cores=4):
-#     with open(input_json, 'rt') as f:
-#         d = json.load(f)
-
-#     if option == 'bayes':
-#         bayes(d, output_fn, cores=cores)
-#     if option == 'mle':
-#         mle(d, output_fn, cores=cores)
-
-
-def run_click(observed_mutations_file, mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn,
+def main(observed_mutations_file, mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn,
                     dispersion_value, 
                     option,
                     cores):
@@ -105,11 +89,3 @@ def run_click(observed_mutations_file, mutability_file, depths_file, vep_annotat
         mle(d, output_fn, dispersion_value, cores= int(cores))
 
 
-
-if __name__ == "__main__":
-
-    """
-    python src/estimator/main.py --option bayes --cores 2 test/input_estimation.json test/output_estimation_bayes.tsv
-    python src/estimator/main.py --option mle --cores 2 test/input_estimation.json test/output_estimation_mle.tsv
-    """
-    run_click()

--- a/omega/src/mutabilities/assemble.py
+++ b/omega/src/mutabilities/assemble.py
@@ -17,7 +17,7 @@ channels = canonical_channels()
 
 
 from omega import __logger_name__, __version__
-logger = daiquiri.getLogger(__logger_name__ + '.estimator.assemble')
+logger = daiquiri.getLogger(__logger_name__ + '.mutabilities.assemble')
 
 
 
@@ -78,11 +78,6 @@ class Assembler:
         # dict with key = sample, gene, impact
         self.lambdas = self._lambdas()
         logger.debug("lambdas computed")
-        
-        # ** step 4: set up the lookup table of response counts
-        # dict with key = sample, gene, impact
-        self.response = self._response()
-        logger.debug("response computed")
 
 
     def _get_region_contexts(self, gene):
@@ -91,7 +86,7 @@ class Assembler:
         return df['CONTEXT_MUT'].values
         
 
-    def _depth_rescaling(self):
+    def _depths_per_gene(self):
 
         # depths fold change relative to the mean depth per sample
         # used for mutability correction
@@ -103,14 +98,14 @@ class Assembler:
             samples = [c for c in self.mutability.columns if c not in ['GENE', 'CONTEXT_MUT']]
             for s in samples:
                 depths = np.nan_to_num(df[s].values.astype(np.float32))
-                res[(s, g)] = depths.astype(np.float32) / depths.mean()
+                res[(s, g)] = depths.astype(np.float32)
         return res
 
 
     def _mutability(self):
 
         res = {}
-        rescaling_dict = self._depth_rescaling()
+        depths_dict = self._depths_per_gene()
         samples = [c for c in self.mutability.columns if c not in ['GENE', 'CONTEXT_MUT']]
         
         for g in self.genes:
@@ -128,114 +123,13 @@ class Assembler:
                 # TODO
                 # revise if this .get(x, 0) is the right way of solving this
                 mutability_sample = np.array(list(map(lambda x: mutability_sample_dict.get(x, 0), region_contexts)))
-                fold_change = rescaling_dict[(s, g)]
-                mutability_vector = mutability_sample * fold_change
-                res[(s, g)] = mutability_vector.astype(np.float32)
+                absolute_mutability_vector = mutability_sample * depths_dict[(s, g)]
+                res[(s, g)] = absolute_mutability_vector.astype(np.float32)
 
-        return res
-
-
-    def _context_indicators(self):
-
-        context_indicator_dict = {}
-        for g in self.genes:
-            df = self.depths[self.depths['GENE'] == g]
-            for c in channels:
-                context_indicator = df['CONTEXT_MUT'].apply(lambda x: x == c).values
-                context_indicator_dict[(g, c)] = context_indicator.astype(np.float32)
-        return context_indicator_dict
-
-
-    def _impact_indicators(self):
-
-        res = {}
-        for g in self.genes:
-            df = self.depths[self.depths['GENE'] == g]
-            for i in self.group.namespace('impacts'):
-                res[(g, i)] = df['IMPACT'].apply(lambda x: x == i).values.astype(np.float32)
         return res
 
 
     def _lambdas(self):
-
         res = {}
-        impact_indicator_dict = self._impact_indicators()
-        context_indicator_dict = self._context_indicators()
         mutability_dict = self._mutability()
-        for g in self.genes:
-            for s in self.group.namespace('samples'):
-                mutability = mutability_dict[(s, g)]
-                for i in self.group.namespace('impacts'):
-                    impact_indicator = impact_indicator_dict[(g, i)]
-                    lambda_vector = np.array([np.sum(mutability * impact_indicator * context_indicator_dict[(g, c)]) for c in channels])
-                    res[(s, g, i)] = lambda_vector.astype(np.float32)
-        return res
-
-
-    def _response(self):
-
-        res = {}
-        self.mut_counts['CONTEXT_MUT'] = self.mut_counts['CONTEXT_MUT'].astype('category')
-        self.mut_counts['CONTEXT_MUT'] = self.mut_counts['CONTEXT_MUT'].cat.set_categories(channels)
-        self.mut_counts.sort_values(['GENE', 'IMPACT', 'CONTEXT_MUT'], inplace=True)
-        
-        genes_impacts = set(zip(self.mut_counts['GENE'].values, self.mut_counts['IMPACT'].values))
-        for g, i in genes_impacts:
-            df = self.mut_counts[(self.mut_counts['GENE'] == g) & (self.mut_counts['IMPACT'] == i)]
-            for s in self.mut_counts.columns:
-                if s not in ['GENE', 'IMPACT', 'CONTEXT_MUT']:
-                    d = dict(zip(df['CONTEXT_MUT'].values, df[s].values))
-                    res[(s, g, i)] = np.array([d.get(c, 0.) for c in channels]).astype(np.float32)
-        return res
-
-
-    def input_data(self, sample_set, gene_set, impact_set):
-
-        try:
-            counts_tensors = [tf.convert_to_tensor(v, dtype=tf.float32) 
-                            for (s, g, i), v in self.response.items() if (s in sample_set) and (g in gene_set) and (i in impact_set)]
-            n = functools.reduce(tf.math.add, counts_tensors)
-
-        except TypeError as e:
-            if "reduce() of empty iterable with no initial value" in str(e):
-                logger.warning(f"No mutations found for {sample_set}, {impact_set}, {gene_set}, filling the counts with 0s.")
-                n = [0.] * 96
-            else:
-                logger.error(f"Unknown error {e} for {sample_set}, {impact_set}, {gene_set}.")
-                raise
-
-        # Convert n to a tensor if it's not already one
-        if not isinstance(n, tf.Tensor):
-            n = tf.convert_to_tensor(n, dtype=tf.float32)
-
-        try:
-            lambda_tensors = [tf.convert_to_tensor(v, dtype=tf.float32) 
-                            for (s, g, i), v in self.lambdas.items() if (s in sample_set) and (g in gene_set) and (i in impact_set)]
-            l = functools.reduce(tf.math.add, lambda_tensors)
-
-        except Exception as e:
-            logger.warning(f"Lambda tensors for {sample_set}, {impact_set}, {gene_set} found error in {e}")
-            l = [0.] * 96
-
-        # Convert l to a tensor if it's not already one
-        if not isinstance(l, tf.Tensor):
-            l = tf.convert_to_tensor(l, dtype=tf.float32)
-
-        return l, n
-
-
-    def input_generator(self):
-        for gene_term, gene_set in self.group.group['genes'].items():
-            for sample_term, sample_set in self.group.group['samples'].items():
-                for impact_term, impact_set in self.group.group['impacts'].items():
-                    # logger.debug("{}{}{}".format(sample_set, gene_set, impact_set))
-                    l, n = self.input_data(sample_set, gene_set, impact_set)
-
-                    # either because of lambdas going to 0 or because of an error and then l put to 0, skip testing that group
-                    if np.all(l == 0.):
-                        logger.warning(f"Lambdas are 0, we are ignoring this case {sample_set}, {impact_set}, {gene_set}.")
-                        continue
-                    if np.all(n == 0.):
-                        logger.warning(f"There is no mutation, we are ignoring this case {sample_set}, {impact_set}, {gene_set}.")
-                        continue
-                    yield (gene_term, sample_term, impact_term, gene_set, sample_set, impact_set, l, n)
+        return mutability_dict

--- a/omega/src/mutabilities/assemble.py
+++ b/omega/src/mutabilities/assemble.py
@@ -1,0 +1,241 @@
+import os
+import json
+import functools
+import operator
+import daiquiri
+import numpy as np
+
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3' 
+
+import tensorflow as tf
+import tensorflow_probability as tfp
+tfd = tfp.distributions
+tfb = tfp.bijectors
+
+from omega.src.estimator.context_store import canonical_channels
+channels = canonical_channels()
+
+
+from omega import __logger_name__, __version__
+logger = daiquiri.getLogger(__logger_name__ + '.estimator.assemble')
+
+
+
+class Grouping:
+
+    def __init__(self):
+        
+        self.group = {}
+
+    def add_group(self, key, fn):
+
+        assert(key in ['samples', 'genes', 'impacts'])
+        with open(fn, 'rt') as f:
+            self.group[key] = json.load(f)
+
+    def namespace(self, key):
+        
+        return set(functools.reduce(operator.add, self.group[key].values()))
+
+
+class Assembler:
+
+    def __init__(self, depths, vep, mut_counts, mutability, group):
+
+        self.mut_counts = mut_counts
+        self.mutability = mutability
+        
+        # dict with groupings for sample, gene and impact terms, respectively
+        # uses "samples", "genes" and "impacts" as keys
+        self.group = group
+
+        # ** SETUP **
+
+        # ** step 1 : merge annotated sites with depths dataframe
+        depths.columns = ["CHROM", "POS"] + list(depths.columns[2:])
+        if "CONTEXT" in depths.columns: depths = depths.drop("CONTEXT", axis = 1)
+
+        reduced_vep = vep[["CHROM", "POS", "CONTEXT_MUT", "GENE", "IMPACT"]]
+        depths_merge_context_impact = reduced_vep.merge(depths, on=["CHROM", "POS"], how = "left")
+        logger.debug("depths annotated")
+        del depths
+        del reduced_vep
+
+
+        # ** step 2: create depths attribute
+        self.depths = depths_merge_context_impact
+
+        self.genes = list(set(self.group.namespace('genes')) & set(self.depths['GENE'].unique()))
+
+        logger.debug("Samples")
+        logger.debug(self.group.namespace('samples'))
+        logger.debug("Genes")
+        logger.debug(self.genes)
+        logger.debug("Impacts")
+        logger.debug(self.group.namespace('impacts'))
+
+        # ** step 3: set up lookup table of lambdas
+        # dict with key = sample, gene, impact
+        self.lambdas = self._lambdas()
+        logger.debug("lambdas computed")
+        
+        # ** step 4: set up the lookup table of response counts
+        # dict with key = sample, gene, impact
+        self.response = self._response()
+        logger.debug("response computed")
+
+
+    def _get_region_contexts(self, gene):
+
+        df = self.depths[self.depths['GENE'] == gene]
+        return df['CONTEXT_MUT'].values
+        
+
+    def _depth_rescaling(self):
+
+        # depths fold change relative to the mean depth per sample
+        # used for mutability correction
+
+        res = {}
+
+        for g in self.genes:
+            df = self.depths[self.depths['GENE'] == g]
+            samples = [c for c in self.mutability.columns if c not in ['GENE', 'CONTEXT_MUT']]
+            for s in samples:
+                depths = np.nan_to_num(df[s].values.astype(np.float32))
+                res[(s, g)] = depths.astype(np.float32) / depths.mean()
+        return res
+
+
+    def _mutability(self):
+
+        res = {}
+        rescaling_dict = self._depth_rescaling()
+        samples = [c for c in self.mutability.columns if c not in ['GENE', 'CONTEXT_MUT']]
+        
+        for g in self.genes:
+            mutability_gene = self.mutability[self.mutability['GENE'] == g]
+            region_contexts = self._get_region_contexts(g)
+            for s in samples:
+                mutability_sample_dict = dict(zip(mutability_gene['CONTEXT_MUT'].values, mutability_gene[s].values))
+
+                # # This introduces misleading results, if no mutability for a given context, then no mutations can be randomized there.
+                # # omega preprocessing already adds some pseudocount due to the potential absence of mutations in specific trinucleotide contexts
+                # #     if a 0 reaches this step it is a real 0 either of depth or of expected number of mutations.
+                # for c, value in mutability_sample_dict.items():
+                #     mutability_sample_dict.update({c: max(value, 1e-4)})
+
+                # TODO
+                # revise if this .get(x, 0) is the right way of solving this
+                mutability_sample = np.array(list(map(lambda x: mutability_sample_dict.get(x, 0), region_contexts)))
+                fold_change = rescaling_dict[(s, g)]
+                mutability_vector = mutability_sample * fold_change
+                res[(s, g)] = mutability_vector.astype(np.float32)
+
+        return res
+
+
+    def _context_indicators(self):
+
+        context_indicator_dict = {}
+        for g in self.genes:
+            df = self.depths[self.depths['GENE'] == g]
+            for c in channels:
+                context_indicator = df['CONTEXT_MUT'].apply(lambda x: x == c).values
+                context_indicator_dict[(g, c)] = context_indicator.astype(np.float32)
+        return context_indicator_dict
+
+
+    def _impact_indicators(self):
+
+        res = {}
+        for g in self.genes:
+            df = self.depths[self.depths['GENE'] == g]
+            for i in self.group.namespace('impacts'):
+                res[(g, i)] = df['IMPACT'].apply(lambda x: x == i).values.astype(np.float32)
+        return res
+
+
+    def _lambdas(self):
+
+        res = {}
+        impact_indicator_dict = self._impact_indicators()
+        context_indicator_dict = self._context_indicators()
+        mutability_dict = self._mutability()
+        for g in self.genes:
+            for s in self.group.namespace('samples'):
+                mutability = mutability_dict[(s, g)]
+                for i in self.group.namespace('impacts'):
+                    impact_indicator = impact_indicator_dict[(g, i)]
+                    lambda_vector = np.array([np.sum(mutability * impact_indicator * context_indicator_dict[(g, c)]) for c in channels])
+                    res[(s, g, i)] = lambda_vector.astype(np.float32)
+        return res
+
+
+    def _response(self):
+
+        res = {}
+        self.mut_counts['CONTEXT_MUT'] = self.mut_counts['CONTEXT_MUT'].astype('category')
+        self.mut_counts['CONTEXT_MUT'] = self.mut_counts['CONTEXT_MUT'].cat.set_categories(channels)
+        self.mut_counts.sort_values(['GENE', 'IMPACT', 'CONTEXT_MUT'], inplace=True)
+        
+        genes_impacts = set(zip(self.mut_counts['GENE'].values, self.mut_counts['IMPACT'].values))
+        for g, i in genes_impacts:
+            df = self.mut_counts[(self.mut_counts['GENE'] == g) & (self.mut_counts['IMPACT'] == i)]
+            for s in self.mut_counts.columns:
+                if s not in ['GENE', 'IMPACT', 'CONTEXT_MUT']:
+                    d = dict(zip(df['CONTEXT_MUT'].values, df[s].values))
+                    res[(s, g, i)] = np.array([d.get(c, 0.) for c in channels]).astype(np.float32)
+        return res
+
+
+    def input_data(self, sample_set, gene_set, impact_set):
+
+        try:
+            counts_tensors = [tf.convert_to_tensor(v, dtype=tf.float32) 
+                            for (s, g, i), v in self.response.items() if (s in sample_set) and (g in gene_set) and (i in impact_set)]
+            n = functools.reduce(tf.math.add, counts_tensors)
+
+        except TypeError as e:
+            if "reduce() of empty iterable with no initial value" in str(e):
+                logger.warning(f"No mutations found for {sample_set}, {impact_set}, {gene_set}, filling the counts with 0s.")
+                n = [0.] * 96
+            else:
+                logger.error(f"Unknown error {e} for {sample_set}, {impact_set}, {gene_set}.")
+                raise
+
+        # Convert n to a tensor if it's not already one
+        if not isinstance(n, tf.Tensor):
+            n = tf.convert_to_tensor(n, dtype=tf.float32)
+
+        try:
+            lambda_tensors = [tf.convert_to_tensor(v, dtype=tf.float32) 
+                            for (s, g, i), v in self.lambdas.items() if (s in sample_set) and (g in gene_set) and (i in impact_set)]
+            l = functools.reduce(tf.math.add, lambda_tensors)
+
+        except Exception as e:
+            logger.warning(f"Lambda tensors for {sample_set}, {impact_set}, {gene_set} found error in {e}")
+            l = [0.] * 96
+
+        # Convert l to a tensor if it's not already one
+        if not isinstance(l, tf.Tensor):
+            l = tf.convert_to_tensor(l, dtype=tf.float32)
+
+        return l, n
+
+
+    def input_generator(self):
+        for gene_term, gene_set in self.group.group['genes'].items():
+            for sample_term, sample_set in self.group.group['samples'].items():
+                for impact_term, impact_set in self.group.group['impacts'].items():
+                    # logger.debug("{}{}{}".format(sample_set, gene_set, impact_set))
+                    l, n = self.input_data(sample_set, gene_set, impact_set)
+
+                    # either because of lambdas going to 0 or because of an error and then l put to 0, skip testing that group
+                    if np.all(l == 0.):
+                        logger.warning(f"Lambdas are 0, we are ignoring this case {sample_set}, {impact_set}, {gene_set}.")
+                        continue
+                    if np.all(n == 0.):
+                        logger.warning(f"There is no mutation, we are ignoring this case {sample_set}, {impact_set}, {gene_set}.")
+                        continue
+                    yield (gene_term, sample_term, impact_term, gene_set, sample_set, impact_set, l, n)

--- a/omega/src/mutabilities/assemble.py
+++ b/omega/src/mutabilities/assemble.py
@@ -70,8 +70,7 @@ class Assembler:
         logger.debug(self.group.namespace('samples'))
         logger.debug("Genes")
         logger.debug(self.genes)
-        logger.debug("Impacts")
-        logger.debug(self.group.namespace('impacts'))
+
 
         # ** step 3: compute mutability per site
         self._lambdas()

--- a/omega/src/mutabilities/assemble.py
+++ b/omega/src/mutabilities/assemble.py
@@ -40,9 +40,8 @@ class Grouping:
 
 class Assembler:
 
-    def __init__(self, depths, vep, mut_counts, mutability, group):
+    def __init__(self, depths, vep, mutability, group):
 
-        self.mut_counts = mut_counts
         self.mutability = mutability
         
         # dict with groupings for sample, gene and impact terms, respectively
@@ -58,13 +57,13 @@ class Assembler:
         reduced_vep = vep[["CHROM", "POS", "CONTEXT_MUT", "GENE", "IMPACT"]]
         depths_merge_context_impact = reduced_vep.merge(depths, on=["CHROM", "POS"], how = "left")
         logger.debug("depths annotated")
+        self.mutabilities_per_site = reduced_vep.copy()
         del depths
         del reduced_vep
 
 
         # ** step 2: create depths attribute
         self.depths = depths_merge_context_impact
-
         self.genes = list(set(self.group.namespace('genes')) & set(self.depths['GENE'].unique()))
 
         logger.debug("Samples")
@@ -74,10 +73,9 @@ class Assembler:
         logger.debug("Impacts")
         logger.debug(self.group.namespace('impacts'))
 
-        # ** step 3: set up lookup table of lambdas
-        # dict with key = sample, gene, impact
-        self.lambdas = self._lambdas()
-        logger.debug("lambdas computed")
+        # ** step 3: compute mutability per site
+        self._lambdas()
+        logger.debug("mutabilities per site computed")
 
 
     def _get_region_contexts(self, gene):
@@ -86,7 +84,7 @@ class Assembler:
         return df['CONTEXT_MUT'].values
         
 
-    def _depths_per_gene(self):
+    def _depth_rescaling(self):
 
         # depths fold change relative to the mean depth per sample
         # used for mutability correction
@@ -98,14 +96,14 @@ class Assembler:
             samples = [c for c in self.mutability.columns if c not in ['GENE', 'CONTEXT_MUT']]
             for s in samples:
                 depths = np.nan_to_num(df[s].values.astype(np.float32))
-                res[(s, g)] = depths.astype(np.float32)
+                res[(s, g)] = depths.astype(np.float32) / depths.mean()
         return res
 
 
     def _mutability(self):
 
         res = {}
-        depths_dict = self._depths_per_gene()
+        rescaling_dict = self._depth_rescaling()
         samples = [c for c in self.mutability.columns if c not in ['GENE', 'CONTEXT_MUT']]
         
         for g in self.genes:
@@ -123,13 +121,18 @@ class Assembler:
                 # TODO
                 # revise if this .get(x, 0) is the right way of solving this
                 mutability_sample = np.array(list(map(lambda x: mutability_sample_dict.get(x, 0), region_contexts)))
-                absolute_mutability_vector = mutability_sample * depths_dict[(s, g)]
-                res[(s, g)] = absolute_mutability_vector.astype(np.float32)
+                fold_change = rescaling_dict[(s, g)]
+                mutability_vector = mutability_sample * fold_change
+                res[(s, g)] = mutability_vector.astype(np.float32)
 
         return res
 
-
     def _lambdas(self):
-        res = {}
         mutability_dict = self._mutability()
-        return mutability_dict
+        samples = list(self.group.namespace('samples'))
+
+        self.mutabilities_per_site[samples] = 0.
+        for g in self.genes:
+            for s in samples:
+                mutability = mutability_dict[(s, g)]
+                self.mutabilities_per_site.loc[self.mutabilities_per_site["GENE"] == g, s] = mutability

--- a/omega/src/mutabilities/main.py
+++ b/omega/src/mutabilities/main.py
@@ -1,0 +1,88 @@
+import os
+import tqdm
+import daiquiri
+import warnings
+
+import pandas as pd
+
+# from enum import Enum
+from multiprocessing import Pool
+
+
+from omega import __logger_name__, __version__
+from omega.src.mutabilities.assemble import Grouping, Assembler
+from omega.src.estimator.omega import bayes_infer, mle_infer
+
+logger = daiquiri.getLogger(__logger_name__ + '.estimator')
+
+warnings.filterwarnings(module='tensorflow*', action='ignore')
+
+
+def prepare_data(d):
+
+    mut_counts = pd.read_csv(d['observed_mutations_file'], sep='\t')
+    mutability = pd.read_csv(d['mutability_file'], sep='\t')
+    depths = pd.read_csv(d['depths_file'], sep='\t')
+    vep = pd.read_csv(d['vep_annotation_file'], sep='\t')
+
+    # group collects the grouping of samples, genes and impacts
+    # the group instance will be passed to the Assembler so that 
+    # it can create a data grid in accordance with the grouping
+    group = Grouping()
+    group.add_group('samples', os.path.join(d['grouping_folder'], 'group_samples.json'))
+    group.add_group('genes', os.path.join(d['grouping_folder'], 'group_genes.json'))
+    group.add_group('impacts', os.path.join(d['grouping_folder'], 'group_impacts.json'))
+
+    ground_control = Assembler(depths, vep, mut_counts, mutability, group)
+    return list(ground_control.input_generator())
+    
+
+def get_mutabilities(input_json: str, output_fn: str, dispersion : float, cores=4):
+    logger.info("Running in mle mode")
+
+    input_grid = prepare_data(input_json)
+    logger.info("Data prepared")
+
+    df = pd.DataFrame(input_grid)
+    df.to_csv(output_fn, sep='\t', index=False)
+
+
+
+# class ModelType(str, Enum):
+#     bayes = "bayes"
+#     mle = "mle"
+
+
+# def run(input_json: str, output_fn: str, option: ModelType=ModelType.bayes, cores=4):
+#     with open(input_json, 'rt') as f:
+#         d = json.load(f)
+
+#     if option == 'bayes':
+#         bayes(d, output_fn, cores=cores)
+#     if option == 'mle':
+#         mle(d, output_fn, cores=cores)
+
+
+def run_click(observed_mutations_file, mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn,
+                    dispersion_value, 
+                    option,
+                    cores):
+    
+    d = {'observed_mutations_file' : observed_mutations_file,
+            'mutability_file': mutability_file,
+            'depths_file': depths_file,
+            'vep_annotation_file': vep_annotation_file,
+            'grouping_folder' : grouping_folder
+            }
+
+    get_mutabilities(d, output_fn, dispersion_value, cores= int(cores))
+
+
+
+if __name__ == "__main__":
+
+    """
+    python src/estimator/main.py --option bayes --cores 2 test/input_estimation.json test/output_estimation_bayes.tsv
+    python src/estimator/main.py --option mle --cores 2 test/input_estimation.json test/output_estimation_mle.tsv
+    """
+    run_click()

--- a/omega/src/mutabilities/main.py
+++ b/omega/src/mutabilities/main.py
@@ -11,16 +11,14 @@ from multiprocessing import Pool
 
 from omega import __logger_name__, __version__
 from omega.src.mutabilities.assemble import Grouping, Assembler
-from omega.src.estimator.omega import bayes_infer, mle_infer
 
-logger = daiquiri.getLogger(__logger_name__ + '.estimator')
+logger = daiquiri.getLogger(__logger_name__ + '.mutabilities')
 
 warnings.filterwarnings(module='tensorflow*', action='ignore')
 
 
 def prepare_data(d):
 
-    mut_counts = pd.read_csv(d['observed_mutations_file'], sep='\t')
     mutability = pd.read_csv(d['mutability_file'], sep='\t')
     depths = pd.read_csv(d['depths_file'], sep='\t')
     vep = pd.read_csv(d['vep_annotation_file'], sep='\t')
@@ -33,11 +31,12 @@ def prepare_data(d):
     group.add_group('genes', os.path.join(d['grouping_folder'], 'group_genes.json'))
     group.add_group('impacts', os.path.join(d['grouping_folder'], 'group_impacts.json'))
 
-    ground_control = Assembler(depths, vep, mut_counts, mutability, group)
+    ground_control = Assembler(depths, vep, mutability, group)
+    print(ground_control)
     return list(ground_control.input_generator())
     
 
-def get_mutabilities(input_json: str, output_fn: str, dispersion : float, cores=4):
+def get_mutabilities(input_json: str, output_fn: str,  cores=4):
     logger.info("Running in mle mode")
 
     input_grid = prepare_data(input_json)
@@ -48,34 +47,15 @@ def get_mutabilities(input_json: str, output_fn: str, dispersion : float, cores=
 
 
 
-# class ModelType(str, Enum):
-#     bayes = "bayes"
-#     mle = "mle"
-
-
-# def run(input_json: str, output_fn: str, option: ModelType=ModelType.bayes, cores=4):
-#     with open(input_json, 'rt') as f:
-#         d = json.load(f)
-
-#     if option == 'bayes':
-#         bayes(d, output_fn, cores=cores)
-#     if option == 'mle':
-#         mle(d, output_fn, cores=cores)
-
-
-def run_click(observed_mutations_file, mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn,
-                    dispersion_value, 
-                    option,
-                    cores):
+def run_click( mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, cores):
     
-    d = {'observed_mutations_file' : observed_mutations_file,
-            'mutability_file': mutability_file,
+    d = {'mutability_file': mutability_file,
             'depths_file': depths_file,
             'vep_annotation_file': vep_annotation_file,
             'grouping_folder' : grouping_folder
             }
 
-    get_mutabilities(d, output_fn, dispersion_value, cores= int(cores))
+    get_mutabilities(d, output_fn, cores= int(cores))
 
 
 

--- a/omega/src/mutabilities/main.py
+++ b/omega/src/mutabilities/main.py
@@ -1,12 +1,8 @@
 import os
-import tqdm
 import daiquiri
 import warnings
 
 import pandas as pd
-
-# from enum import Enum
-from multiprocessing import Pool
 
 
 from omega import __logger_name__, __version__
@@ -38,7 +34,7 @@ def get_mutabilities(input_json: str, output_fn: str,  cores=4):
     df_mutabilities.to_csv(output_fn, header = True, index = False, sep = '\t')
     logger.info("Mutabilities per site stored")
 
-def run_click( mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, cores):
+def main( mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, cores):
     
     d = {'mutability_file': mutability_file,
             'depths_file': depths_file,
@@ -50,10 +46,3 @@ def run_click( mutability_file, depths_file, vep_annotation_file, grouping_folde
 
 
 
-if __name__ == "__main__":
-
-    """
-    python src/estimator/main.py --option bayes --cores 2 test/input_estimation.json test/output_estimation_bayes.tsv
-    python src/estimator/main.py --option mle --cores 2 test/input_estimation.json test/output_estimation_mle.tsv
-    """
-    run_click()

--- a/omega/src/mutabilities/main.py
+++ b/omega/src/mutabilities/main.py
@@ -14,6 +14,13 @@ warnings.filterwarnings(module='tensorflow*', action='ignore')
 
 
 def mutabilities_per_site(d):
+    """
+    This function computes the mutabilities per site using the provided data files.
+    It reads the mutability, depths, and VEP annotation files,
+    and then creates a data grid
+    based on the grouping of samples, genes, and impacts.
+    The resulting data grid is returned as a DataFrame.
+    """
 
     mutability = pd.read_csv(d['mutability_file'], sep='\t')
     depths = pd.read_csv(d['depths_file'], sep='\t')
@@ -29,10 +36,6 @@ def mutabilities_per_site(d):
     ground_control = Assembler(depths, vep, mutability, group)
     return ground_control.mutabilities_per_site
 
-def get_mutabilities(input_json: str, output_fn: str,  cores=4):
-    df_mutabilities = mutabilities_per_site(input_json)
-    df_mutabilities.to_csv(output_fn, header = True, index = False, sep = '\t')
-    logger.info("Mutabilities per site stored")
 
 def main( mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, cores):
     
@@ -42,7 +45,9 @@ def main( mutability_file, depths_file, vep_annotation_file, grouping_folder, ou
             'grouping_folder' : grouping_folder
             }
 
-    get_mutabilities(d, output_fn, cores= int(cores))
+    df_mutabilities = mutabilities_per_site(d)
+    df_mutabilities.to_csv(output_fn, header = True, index = False, sep = '\t')
+    logger.info("Mutabilities per site stored")
 
 
 

--- a/omega/src/mutabilities/main.py
+++ b/omega/src/mutabilities/main.py
@@ -17,7 +17,7 @@ logger = daiquiri.getLogger(__logger_name__ + '.mutabilities')
 warnings.filterwarnings(module='tensorflow*', action='ignore')
 
 
-def prepare_data(d):
+def mutabilities_per_site(d):
 
     mutability = pd.read_csv(d['mutability_file'], sep='\t')
     depths = pd.read_csv(d['depths_file'], sep='\t')
@@ -29,23 +29,14 @@ def prepare_data(d):
     group = Grouping()
     group.add_group('samples', os.path.join(d['grouping_folder'], 'group_samples.json'))
     group.add_group('genes', os.path.join(d['grouping_folder'], 'group_genes.json'))
-    group.add_group('impacts', os.path.join(d['grouping_folder'], 'group_impacts.json'))
 
     ground_control = Assembler(depths, vep, mutability, group)
-    print(ground_control)
-    return list(ground_control.input_generator())
-    
+    return ground_control.mutabilities_per_site
 
 def get_mutabilities(input_json: str, output_fn: str,  cores=4):
-    logger.info("Running in mle mode")
-
-    input_grid = prepare_data(input_json)
-    logger.info("Data prepared")
-
-    df = pd.DataFrame(input_grid)
-    df.to_csv(output_fn, sep='\t', index=False)
-
-
+    df_mutabilities = mutabilities_per_site(input_json)
+    df_mutabilities.to_csv(output_fn, header = True, index = False, sep = '\t')
+    logger.info("Mutabilities per site stored")
 
 def run_click( mutability_file, depths_file, vep_annotation_file, grouping_folder, output_fn, cores):
     

--- a/omega/src/preprocessing/compute_mutabilities.py
+++ b/omega/src/preprocessing/compute_mutabilities.py
@@ -681,7 +681,7 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
                                                             ].reset_index(drop = True).groupby(by = 'GENE')[samples].sum()
         )
 
-        mutation_numbers_full_genes = mutation_numbers[mutation_numbers["GENE"] == mutation_numbers["GENE_BASE"]                                                       ]
+        mutation_numbers_full_genes = mutation_numbers[mutation_numbers["GENE"] == mutation_numbers["GENE_BASE"]]
         print(mutation_numbers_full_genes)
 
         mutation_numbers_gene_regions = mutation_numbers[mutation_numbers["GENE"] != mutation_numbers["GENE_BASE"]]
@@ -711,8 +711,11 @@ def compute_mutabilities_wrapper(all_possible_sites_annotated_file,
 
 
         # Count how many synonymous mutations are there in each sample irrespective of the gene
-        syn_muts_per_sample = obs_muts_per_gene_impact_context_sample_wide[
-                                                            obs_muts_per_gene_impact_context_sample_wide["IMPACT"] == "synonymous"
+        # restrict to full genes only to avoid counting mutations more than once
+        full_genes_names = sorted(mutation_numbers_full_genes.index)
+        obs_muts_per_gene_impact_context_sample_wide_only_full_genes = obs_muts_per_gene_impact_context_sample_wide[obs_muts_per_gene_impact_context_sample_wide["GENE"].isin(full_genes_names)]
+        syn_muts_per_sample = obs_muts_per_gene_impact_context_sample_wide_only_full_genes[
+                                                            obs_muts_per_gene_impact_context_sample_wide_only_full_genes["IMPACT"] == "synonymous"
                                                         ].reset_index(drop = True)[samples].sum()
         syn_muts_per_sample_df = pd.DataFrame(syn_muts_per_sample).T
 

--- a/omega/src/preprocessing/main.py
+++ b/omega/src/preprocessing/main.py
@@ -70,5 +70,3 @@ def main(preprocessing_mode,
                                         absent_synonymous, synonymous_mut_rates_file
                                     )
 
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
## Human summary

Add functionality of computing mutability per site. This can be taken as the number of mutations expected at a given site.

## AI generated summary
This pull request introduces a new feature for computing mutabilities per site and integrates it into the existing `omega` CLI tool. It includes the addition of a new module for mutabilities computation, updates to the CLI commands, and refactoring of related code.

### New Feature: Mutabilities Computation

* **New `mutabilities` module**: Added a new module (`omega/src/mutabilities`) with two main components:
  - [`assemble.py`](diffhunk://#diff-09ff1f562750196ccbc6ea2d715c9178c4517fd2fb9c59ba258027bd3572a165R1-R137): Implements the `Grouping` and `Assembler` classes for handling groupings (e.g., samples, genes) and computing mutabilities per site. Includes methods for depth rescaling and mutability computation.
  - [`main.py`](diffhunk://#diff-924f0122b878eb0f3df383d47d54f67c02258429d97d5eaed5b7d11a2625f9e9R1-R59): Provides the entry point for the mutabilities computation, including the `run_click` function, which integrates with the CLI.

### CLI Enhancements

* **New `mutabilities` command**: Added a new CLI command to run mutabilities analysis, including options for input files, output filename, and cores.
* **Updated help messages**: Refined help descriptions for existing commands to improve clarity (e.g., changing "Build datasets" to "Build tables"). [[1]](diffhunk://#diff-ec2d60bc16ce718a0568d938c74902911ee0c4d8a0d741bef286ebd7f0515edcL34-R35) [[2]](diffhunk://#diff-ec2d60bc16ce718a0568d938c74902911ee0c4d8a0d741bef286ebd7f0515edcL67-R68)

### Integration with Existing Code

* **Import mutabilities main function**: Imported `run_click` from `omega/src/mutabilities/main.py` into `omega/main.py` for CLI integration.